### PR TITLE
For rules pages (.md), make table of contents always be available for quick navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ There are two types of [pages](./src/pages):
 - `.astro` files, which are for writing HTML + Javascript. These are used for the, uh, artisan-crafted websights.
 - `.md` files, which you can write in Markdown and most of the HTML is handled for you. This is ideal for the rules, where you wanna focus on content and don't need a ton of Pretty Websights.
 
-When writing `.md` files, the headers (`## This is a Second-Level header`) can be turned into a table of contents. Just insert a `## Table of Contents` header and it'll generate it for you.
+When writing `.md` files, the headers (`## This is a Second-Level header`) will be used for the table of contents.
 
 ### Updating the Card Database
 I took a gander at [the nandeck Excel spreadsheet](https://discord.com/channels/1097910841770262600/1097911414548594698/1134311635855605790) and saved the first tab as a CSV. When the site is deployed, it generates a `<table>` from that. So as you add cards, it SHOULD be as easy as updating [the CSV file][./src/cards/cards.csv]?

--- a/README.md
+++ b/README.md
@@ -56,3 +56,4 @@ The site should start on `http://localhost:4321` or something. It will tell you 
 
 ## Credits
 - Discord logo vector by [Gil Barbara](https://github.com/gilbarbara/logos). Used under the CC0 license.
+- Table of contents generator based on a blog post by [Kevin Lee Drum](https://kld.dev/building-table-of-contents/).

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,7 +1,6 @@
 import { defineConfig } from 'astro/config';
 import tailwind from "@astrojs/tailwind";
 import alpinejs from "@astrojs/alpinejs";
-import remarkToc from 'remark-toc';
 import { rehypeHeadingIds } from '@astrojs/markdown-remark';
 import rehypeAutolinkHeadings from "rehype-autolink-headings";
 import { toString } from 'hast-util-to-string'
@@ -17,7 +16,6 @@ const createSROnlyLabel = (text) => {
 export default defineConfig({
   integrations: [tailwind(), alpinejs()],
   markdown: {
-    remarkPlugins: [remarkToc],
     rehypePlugins: [
       rehypeHeadingIds,
       [

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@astrojs/alpinejs": "^0.3.1",
+    "@astrojs/markdown-remark": "^3.3.0",
     "@astrojs/tailwind": "^5.0.2",
     "@types/alpinejs": "^3.0.0",
     "alpinejs": "^3.0.0",
@@ -19,7 +20,6 @@
     "hast-util-to-string": "^3.0.0",
     "hastscript": "^8.0.0",
     "rehype-autolink-headings": "^7.0.0",
-    "remark-toc": "^9.0.0",
     "sass": "^1.69.4",
     "simple-datatables": "^8.0.0",
     "tailwindcss": "^3.0.24"

--- a/src/components/TableContentsHeading.astro
+++ b/src/components/TableContentsHeading.astro
@@ -1,0 +1,17 @@
+---
+const { heading } = Astro.props;
+---
+<li>
+    <a href={'#' + heading.slug} class="block py-1 px-4 underline text-web-blue" @click="open=false">
+        {heading.text}
+    </a>
+    {
+        heading.subheadings.length > 0 && (
+            <ul class="ml-4 mb-4">
+                {heading.subheadings.map((subheading) => (
+                    <Astro.self heading={subheading} />
+                ))}
+            </ul>
+        )
+    }
+</li>

--- a/src/components/TableContentsList.astro
+++ b/src/components/TableContentsList.astro
@@ -1,5 +1,5 @@
 ---
-import TableContentsHeading from './TableCOntentsHeading.astro';
+import TableContentsHeading from './TableContentsHeading.astro';
 const { headings } = Astro.props;
 const toc = buildToc(headings);
 

--- a/src/components/TableContentsList.astro
+++ b/src/components/TableContentsList.astro
@@ -1,0 +1,22 @@
+---
+import TableContentsHeading from './TableCOntentsHeading.astro';
+const { headings } = Astro.props;
+const toc = buildToc(headings);
+
+function buildToc(headings) {
+    const toc = [];
+    const parentHeadings = new Map();
+    headings.forEach((h) => {
+        const heading = { ...h, subheadings: [] };
+        parentHeadings.set(heading.depth, heading);
+        // Change 2 to 1 if your markdown includes your <h1>
+        if (heading.depth === 2) {
+            toc.push(heading);
+        } else {
+            parentHeadings.get(heading.depth - 1).subheadings.push(heading);
+        }
+    });
+    return toc;
+}
+---
+{toc.map((heading) => <TableContentsHeading heading={heading} />)}

--- a/src/layouts/MarkdownLayout.astro
+++ b/src/layouts/MarkdownLayout.astro
@@ -3,6 +3,7 @@ import SiteLayout from './SiteLayout.astro';
 import TableContentsList from '../components/TableContentsList.astro';
 
 interface Props {
+    headings?: any;
     title: string;
 }
 
@@ -16,25 +17,19 @@ const { title } = Astro.props.frontmatter || Astro.props;
         </div>
 
         <div x-data="{ open: false }">
-            <div class="hidden lg:block absolute -right-52 -top-6">
+            <div class="fixed bottom-6 right-4 xl:right-6">
                 <button
                     id="toc-toggle"
                     type="button"
-                    class="inline-flex items-center justify-center text-gray-800 hover:text-gray-700 dark:text-gray-400 focus:outline-none focus:ring-0 text-sm"
+                    class="flex justify-center items-center w-[52px] h-[52px] text-gray-500 hover:text-gray-900 bg-gray-100 lg:bg-white rounded-full border border-gray-300 lg:border-gray-200 shadow-lg hover:bg-gray-50 focus:ring-4 focus:ring-gray-300 focus:outline-none"
                     aria-controls="toc-sm"
                     @click="open = !open"
                     aria-expanded="false"
                     x-bind:aria-expanded="open.toString()"
                 >
-                    <svg x-description="Icon closed" x-state:on="Menu open" x-state:off="Menu closed" class="block h-8 w-8" :class="{ 'hidden': open, 'block': !(open) }" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
-                    </svg>
+                    <svg xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 0 512 512"><!--! Font Awesome Free 6.4.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. --><path d="M24 56c0-13.3 10.7-24 24-24H80c13.3 0 24 10.7 24 24V176h16c13.3 0 24 10.7 24 24s-10.7 24-24 24H40c-13.3 0-24-10.7-24-24s10.7-24 24-24H56V80H48C34.7 80 24 69.3 24 56zM86.7 341.2c-6.5-7.4-18.3-6.9-24 1.2L51.5 357.9c-7.7 10.8-22.7 13.3-33.5 5.6s-13.3-22.7-5.6-33.5l11.1-15.6c23.7-33.2 72.3-35.6 99.2-4.9c21.3 24.4 20.8 60.9-1.1 84.7L86.8 432H120c13.3 0 24 10.7 24 24s-10.7 24-24 24H32c-9.5 0-18.2-5.6-22-14.4s-2.1-18.9 4.3-25.9l72-78c5.3-5.8 5.4-14.6 .3-20.5zM224 64H480c17.7 0 32 14.3 32 32s-14.3 32-32 32H224c-17.7 0-32-14.3-32-32s14.3-32 32-32zm0 160H480c17.7 0 32 14.3 32 32s-14.3 32-32 32H224c-17.7 0-32-14.3-32-32s14.3-32 32-32zm0 160H480c17.7 0 32 14.3 32 32s-14.3 32-32 32H224c-17.7 0-32-14.3-32-32s14.3-32 32-32z"/></svg>
 
-                    <svg x-description="Icon open" x-state:on="Menu open" x-state:off="Menu closed" class="hidden h-8 w-8" :class="{ 'block': open, 'hidden': !(open) }" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
-                    </svg>
-
-                    <span class="ml-2">Table of Contents</span>
+                    <span class="sr-only">Table of Contents</span>
                 </button>
             </div>
 
@@ -58,7 +53,15 @@ const { title } = Astro.props.frontmatter || Astro.props;
                     x-transition:leave-start="translate-x-0"
                     x-transition:leave-end="translate-x-full"
                 >
-                    <h2 class="mx-4 text-2xl border-b-2 border-lavender border-dashed mb-4">Table of Contents</h2>
+                    <div class="flex justify-between mx-4 border-b-2 border-lavender border-dashed mb-4">
+                        <h2 class="text-2xl">Table of Contents</h2>
+                        <button @click="open=false">
+                            <svg fill="currentColor" viewBox="0 0 20 20" class="w-6 h-6">
+                                <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"></path>
+                            </svg>
+                        </button>
+                        
+                    </div>
                     <div class="relative flex flex-wrap items-center justify-between">
                         <ul id="side-menu" class="w-full float-none flex flex-col">
                             <TableContentsList headings={Astro.props.headings} />

--- a/src/layouts/MarkdownLayout.astro
+++ b/src/layouts/MarkdownLayout.astro
@@ -9,52 +9,63 @@ interface Props {
 const { title } = Astro.props.frontmatter || Astro.props;
 ---
 <SiteLayout title={title}>
-    <h1 class="text-4xl mb-5">{ title }</h1>
-    <div class="markdown-content">
-        <slot />
-    </div>
+    <div class="relative">
+        <h1 class="text-4xl mb-5">{ title }</h1>
+        <div class="markdown-content">
+            <slot />
+        </div>
 
-    <div x-data="{ open: false }">
-        <!-- Offcanvas button trigger -->
-        <button id="navbartoggle" type="button" class="inline-flex items-center justify-center text-gray-800 hover:text-gray-700 dark:text-gray-400 focus:outline-none focus:ring-0" aria-controls="toc-sm" @click="open = !open" aria-expanded="false" x-bind:aria-expanded="open.toString()">
-            <span class="sr-only">Mobile menu</span>
-            <svg x-description="Icon closed" x-state:on="Menu open" x-state:off="Menu closed" class="block h-8 w-8" :class="{ 'hidden': open, 'block': !(open) }" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
-            </svg>
+        <div x-data="{ open: false }">
+            <div class="hidden lg:block absolute -right-52 -top-6">
+                <button
+                    id="toc-toggle"
+                    type="button"
+                    class="inline-flex items-center justify-center text-gray-800 hover:text-gray-700 dark:text-gray-400 focus:outline-none focus:ring-0 text-sm"
+                    aria-controls="toc-sm"
+                    @click="open = !open"
+                    aria-expanded="false"
+                    x-bind:aria-expanded="open.toString()"
+                >
+                    <svg x-description="Icon closed" x-state:on="Menu open" x-state:off="Menu closed" class="block h-8 w-8" :class="{ 'hidden': open, 'block': !(open) }" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
+                    </svg>
 
-            <svg x-description="Icon open" x-state:on="Menu open" x-state:off="Menu closed" class="hidden h-8 w-8" :class="{ 'block': open, 'hidden': !(open) }" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
-            </svg>
-        </button>
+                    <svg x-description="Icon open" x-state:on="Menu open" x-state:off="Menu closed" class="hidden h-8 w-8" :class="{ 'block': open, 'hidden': !(open) }" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                    </svg>
 
-        <div class="fixed w-full h-full inset-0 z-50" id="toc-sm" x-description="Mobile menu" x-show="open" style="display: none;">
-            <!-- overlay on the content -->
-            <span class="fixed bg-gray-900 bg-opacity-70 w-full h-full inset-x-0 top-0"></span>
+                    <span class="ml-2">Table of Contents</span>
+                </button>
+            </div>
 
-            <nav
-                id="toc-sm-nav"
-                class="flex flex-col right-0 w-96 fixed top-0 py-4 bg-white h-full overflow-auto z-40"
-                x-show="open"
-                @click.away="open=false"
-                x-description="Table of Contents"
-                role="menu"
-                aria-orientation="vertical"
-                aria-labelledby="navbartoggle"
-                x-transition:enter="transform transition-transform duration-300"
-                x-transition:enter-start="translate-x-full"
-                x-transition:enter-end="translate-x-0"
-                x-transition:leave="transform transition-transform duration-300"
-                x-transition:leave-start="translate-x-0"
-                x-transition:leave-end="translate-x-full"
-            >
-                <h2 class="mx-4 text-2xl border-b-2 border-lavender border-dashed mb-4">Table of Contents</h2>
-                <div class="relative flex flex-wrap items-center justify-between">
-                    <ul id="side-menu" class="w-full float-none flex flex-col">
-                        <TableContentsList headings={Astro.props.headings} />
-                    </ul>
-                </div>
-            </nav>
+            <div class="fixed w-full h-full inset-0 z-50" id="toc-sm" x-description="Mobile menu" x-show="open" style="display: none;">
+                <!-- grey overlay on the content -->
+                <span class="fixed bg-gray-900 bg-opacity-70 w-full h-full inset-x-0 top-0"></span>
+
+                <nav
+                    id="toc-sm-nav"
+                    class="flex flex-col right-0 w-96 fixed top-0 py-4 bg-white h-full overflow-auto z-40"
+                    x-show="open"
+                    @click.away="open=false"
+                    x-description="Table of Contents"
+                    role="menu"
+                    aria-orientation="vertical"
+                    aria-labelledby="toc-toggle"
+                    x-transition:enter="transform transition-transform duration-300"
+                    x-transition:enter-start="translate-x-full"
+                    x-transition:enter-end="translate-x-0"
+                    x-transition:leave="transform transition-transform duration-300"
+                    x-transition:leave-start="translate-x-0"
+                    x-transition:leave-end="translate-x-full"
+                >
+                    <h2 class="mx-4 text-2xl border-b-2 border-lavender border-dashed mb-4">Table of Contents</h2>
+                    <div class="relative flex flex-wrap items-center justify-between">
+                        <ul id="side-menu" class="w-full float-none flex flex-col">
+                            <TableContentsList headings={Astro.props.headings} />
+                        </ul>
+                    </div>
+                </nav>
+            </div>
         </div>
     </div>
-
 </SiteLayout>

--- a/src/layouts/MarkdownLayout.astro
+++ b/src/layouts/MarkdownLayout.astro
@@ -37,15 +37,11 @@ const { title } = Astro.props.frontmatter || Astro.props;
                 <!-- grey overlay on the content -->
                 <span class="fixed bg-gray-900 bg-opacity-70 w-full h-full inset-x-0 top-0"></span>
 
-                <nav
+                <div
                     id="toc-sm-nav"
                     class="flex flex-col right-0 w-96 fixed top-0 py-4 bg-white h-full overflow-auto z-40"
                     x-show="open"
                     @click.away="open=false"
-                    x-description="Table of Contents"
-                    role="menu"
-                    aria-orientation="vertical"
-                    aria-labelledby="toc-toggle"
                     x-transition:enter="transform transition-transform duration-300"
                     x-transition:enter-start="translate-x-full"
                     x-transition:enter-end="translate-x-0"
@@ -59,15 +55,20 @@ const { title } = Astro.props.frontmatter || Astro.props;
                             <svg fill="currentColor" viewBox="0 0 20 20" class="w-6 h-6">
                                 <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"></path>
                             </svg>
+                            <span class="sr-only">Close</span>
                         </button>
                         
                     </div>
-                    <div class="relative flex flex-wrap items-center justify-between">
-                        <ul id="side-menu" class="w-full float-none flex flex-col">
+                    <nav class="relative flex flex-wrap items-center justify-between" aria-label="Table of Contents">
+                        <ul
+                            id="side-menu"
+                            class="w-full float-none flex flex-col"
+                            x-description="Table of Contents"
+                        >
                             <TableContentsList headings={Astro.props.headings} />
                         </ul>
-                    </div>
-                </nav>
+                    </nav>
+                </div>
             </div>
         </div>
     </div>

--- a/src/layouts/MarkdownLayout.astro
+++ b/src/layouts/MarkdownLayout.astro
@@ -1,5 +1,6 @@
 ---
 import SiteLayout from './SiteLayout.astro';
+import TableContentsList from '../components/TableContentsList.astro';
 
 interface Props {
     title: string;
@@ -12,4 +13,48 @@ const { title } = Astro.props.frontmatter || Astro.props;
     <div class="markdown-content">
         <slot />
     </div>
+
+    <div x-data="{ open: false }">
+        <!-- Offcanvas button trigger -->
+        <button id="navbartoggle" type="button" class="inline-flex items-center justify-center text-gray-800 hover:text-gray-700 dark:text-gray-400 focus:outline-none focus:ring-0" aria-controls="toc-sm" @click="open = !open" aria-expanded="false" x-bind:aria-expanded="open.toString()">
+            <span class="sr-only">Mobile menu</span>
+            <svg x-description="Icon closed" x-state:on="Menu open" x-state:off="Menu closed" class="block h-8 w-8" :class="{ 'hidden': open, 'block': !(open) }" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
+            </svg>
+
+            <svg x-description="Icon open" x-state:on="Menu open" x-state:off="Menu closed" class="hidden h-8 w-8" :class="{ 'block': open, 'hidden': !(open) }" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+            </svg>
+        </button>
+
+        <div class="fixed w-full h-full inset-0 z-50" id="toc-sm" x-description="Mobile menu" x-show="open" style="display: none;">
+            <!-- overlay on the content -->
+            <span class="fixed bg-gray-900 bg-opacity-70 w-full h-full inset-x-0 top-0"></span>
+
+            <nav
+                id="toc-sm-nav"
+                class="flex flex-col right-0 w-96 fixed top-0 py-4 bg-white h-full overflow-auto z-40"
+                x-show="open"
+                @click.away="open=false"
+                x-description="Table of Contents"
+                role="menu"
+                aria-orientation="vertical"
+                aria-labelledby="navbartoggle"
+                x-transition:enter="transform transition-transform duration-300"
+                x-transition:enter-start="translate-x-full"
+                x-transition:enter-end="translate-x-0"
+                x-transition:leave="transform transition-transform duration-300"
+                x-transition:leave-start="translate-x-0"
+                x-transition:leave-end="translate-x-full"
+            >
+                <h2 class="mx-4 text-2xl border-b-2 border-lavender border-dashed mb-4">Table of Contents</h2>
+                <div class="relative flex flex-wrap items-center justify-between">
+                    <ul id="side-menu" class="w-full float-none flex flex-col">
+                        <TableContentsList headings={Astro.props.headings} />
+                    </ul>
+                </div>
+            </nav>
+        </div>
+    </div>
+
 </SiteLayout>

--- a/src/pages/Rules.md
+++ b/src/pages/Rules.md
@@ -8,9 +8,6 @@ I'm working on updating terminology, but the concepts are the same.
 
 Rule Book Build: Pre-Alpha Play-Test 0.2 (Updated: June 27, 2023)
 
-## Table of Contents
-<!-- The 'Table of Contents' header is magic; it'll generate a ToC based on the headers. You don't need to put anything in here. -->
-
 ## Basic Concepts
 The game consists of 2 to 5 players competing against each other to be the single winner. The winner is decided by the player with the most <abbr>Victory Points</abbr> at the end of the game. Each player will have a <abbr>Main Deck</abbr> that consists of 48 cards, and a single, additional special Planet Card. Players assemble their deck before the game begins.
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,7 +30,7 @@
   resolved "https://registry.yarnpkg.com/@astrojs/internal-helpers/-/internal-helpers-0.2.1.tgz#4e2e6aabaa9819f17119aa10f413c4d6122c94cf"
   integrity sha512-06DD2ZnItMwUnH81LBLco3tWjcZ1lGU9rLCCBaeUCGYe9cI0wKyY2W3kDyoW1I6GmcWgt1fu+D1CTvz+FIKf8A==
 
-"@astrojs/markdown-remark@3.3.0":
+"@astrojs/markdown-remark@3.3.0", "@astrojs/markdown-remark@^3.3.0":
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/@astrojs/markdown-remark/-/markdown-remark-3.3.0.tgz#1c341cf1d7a494b658470ca0f000fc809a50bb7d"
   integrity sha512-ezFzEiZygc/ASe2Eul9v1yrTbNGqSbR348UGNXQ4Dtkx8MYRwfiBfmPm6VnEdfIGkW+bi5qIUReKfc7mPVUkIg==
@@ -66,10 +66,10 @@
     postcss "^8.4.28"
     postcss-load-config "^4.0.1"
 
-"@astrojs/telemetry@3.0.3":
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/@astrojs/telemetry/-/telemetry-3.0.3.tgz#a7a87a40de74bfeaae78fc4cbec1f6ec1cbf1c36"
-  integrity sha512-j19Cf5mfyLt9hxgJ9W/FMdAA5Lovfp7/CINNB/7V71GqvygnL7KXhRC3TzfB+PsVQcBtgWZzCXhUWRbmJ64Raw==
+"@astrojs/telemetry@3.0.4":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@astrojs/telemetry/-/telemetry-3.0.4.tgz#566257082c87df84fcc136db23e071e1104b13fd"
+  integrity sha512-A+0c7k/Xy293xx6odsYZuXiaHO0PL+bnDoXOc47sGDF5ffIKdKQGRPFl2NMlCF4L0NqN4Ynbgnaip+pPF0s7pQ==
   dependencies:
     ci-info "^3.8.0"
     debug "^4.3.4"
@@ -656,11 +656,6 @@
   resolved "https://registry.yarnpkg.com/@types/parse5/-/parse5-6.0.3.tgz#705bb349e789efa06f43f128cef51240753424cb"
   integrity sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g==
 
-"@types/ungap__structured-clone@^0.3.0":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@types/ungap__structured-clone/-/ungap__structured-clone-0.3.1.tgz#85ac9f60d400e2b792c76193bbbe64a4ad92e274"
-  integrity sha512-7QlsekF3QYmE+RbRRRq9lfgQLugDdDXTR8E/njp+x9DpRp+n5UsyDLLVne1d3f1h2S7f38x4xEJfHA5NtfiO7Q==
-
 "@types/unist@*", "@types/unist@^3.0.0":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-3.0.1.tgz#778652d02ddec1bfc9e5e938fec8d407b8e56cba"
@@ -765,14 +760,14 @@ array-iterate@^2.0.0:
   integrity sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==
 
 astro@^3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/astro/-/astro-3.3.2.tgz#0439b38b0f476472eddac080f0eba6e46bb1a4c5"
-  integrity sha512-uyimGY0p1gYXKAZe3/RCfbqNbuwpEvPkTKF5TE63Glb9ZgeLUBXu+ZlsG4LIMxCQ40p5F0D5+zuNJdH+om2PQQ==
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/astro/-/astro-3.3.4.tgz#59599bcdf5c77811ed6080c37cf64f29744ba892"
+  integrity sha512-1yy1p8/QpACpToK2bYFxbbPug7+HeUW+IGvkIss2KQDv4pwDk19UbfQrS8aMHtW3nvR7PpBYL/H/Dprcqxy40A==
   dependencies:
     "@astrojs/compiler" "^2.1.0"
     "@astrojs/internal-helpers" "0.2.1"
     "@astrojs/markdown-remark" "3.3.0"
-    "@astrojs/telemetry" "3.0.3"
+    "@astrojs/telemetry" "3.0.4"
     "@babel/core" "^7.22.10"
     "@babel/generator" "^7.22.10"
     "@babel/parser" "^7.22.10"
@@ -949,9 +944,9 @@ camelcase@^7.0.1:
   integrity sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==
 
 caniuse-lite@^1.0.30001538, caniuse-lite@^1.0.30001541:
-  version "1.0.30001551"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001551.tgz#1f2cfa8820bd97c971a57349d7fd8f6e08664a3e"
-  integrity sha512-vtBAez47BoGMMzlbYhfXrMV1kvRF2WP/lqiMuDu1Sb4EE4LKEgjopFDSRtZfdVnslNRpOqV/woE+Xgrwj6VQlg==
+  version "1.0.30001554"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001554.tgz#ba80d88dff9acbc0cd4b7535fc30e0191c5e2e2a"
+  integrity sha512-A2E3U//MBwbJVzebddm1YfNp7Nud5Ip+IPn4BozBmn4KqVX7AvluoIDFWjsv5OkGnKUXQVmMSoMKLa3ScCblcQ==
 
 ccount@^2.0.0:
   version "2.0.1"
@@ -1216,9 +1211,9 @@ dlv@^1.1.3:
   integrity sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==
 
 dset@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/dset/-/dset-3.1.2.tgz#89c436ca6450398396dc6538ea00abc0c54cd45a"
-  integrity sha512-g/M9sqy3oHe477Ar4voQxWtaPIFw1jTdKZuomOjhCcBx9nHUNn0pu6NopuFFrTh/TRZIKEj+76vLWFu9BNKk+Q==
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/dset/-/dset-3.1.3.tgz#c194147f159841148e8e34ca41f638556d9542d2"
+  integrity sha512-20TuZZHCEZ2O71q9/+8BwKwZ0QtD9D8ObhrihJPr+vLLYlSuAU3/zL4cSlgbfeoGHTjCSJBa7NGcrF9/Bx/WJQ==
 
 eastasianwidth@^0.2.0:
   version "0.2.0"
@@ -1226,9 +1221,9 @@ eastasianwidth@^0.2.0:
   integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
 
 electron-to-chromium@^1.4.535:
-  version "1.4.561"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.561.tgz#816f31d9ae01fe58abbf469fca7e125b16befd85"
-  integrity sha512-eS5t4ulWOBfVHdq9SW2dxEaFarj1lPjvJ8PaYMOjY0DecBaj/t4ARziL2IPpDr4atyWwjLFGQ2vo/VCgQFezVQ==
+  version "1.4.567"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.567.tgz#c92e8fbc2bd15df3068d92571733a218a5413add"
+  integrity sha512-8KR114CAYQ4/r5EIEsOmOMqQ9j0MRbJZR3aXD/KFA8RuKzyoUB4XrUCg+l8RUGqTVQgKNIgTpjaG8YHRPAbX2w==
 
 emoji-regex@^10.2.1:
   version "10.3.0"
@@ -1382,7 +1377,7 @@ fast-fifo@^1.1.0, fast-fifo@^1.2.0:
   resolved "https://registry.yarnpkg.com/fast-fifo/-/fast-fifo-1.3.2.tgz#286e31de96eb96d38a97899815740ba2a4f3640c"
   integrity sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==
 
-fast-glob@^3.2.12, fast-glob@^3.3.1:
+fast-glob@^3.3.0, fast-glob@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.1.tgz#784b4e897340f3dbbef17413b3f11acf03c874c4"
   integrity sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==
@@ -1450,6 +1445,11 @@ fsevents@~2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
+
+function-bind@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
+  integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
 
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
@@ -1522,10 +1522,12 @@ has-flag@^3.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
   integrity sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==
 
-has@^1.0.3:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/has/-/has-1.0.4.tgz#2eb2860e000011dae4f1406a86fe80e530fb2ec6"
-  integrity sha512-qdSAmqLF6209RFj4VVItywPMbm3vWylknmB3nvNiUIs72xAimcM8nVYxYr7ncvZq5qzk9MKIZR8ijqD/1QuYjQ==
+hasown@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.0.tgz#f4c513d454a57b7c7e1650778de226b11700546c"
+  integrity sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==
+  dependencies:
+    function-bind "^1.1.2"
 
 hast-util-from-parse5@^7.0.0:
   version "7.1.2"
@@ -1802,11 +1804,11 @@ is-buffer@^2.0.0:
   integrity sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==
 
 is-core-module@^2.13.0:
-  version "2.13.0"
-  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.13.0.tgz#bb52aa6e2cbd49a30c2ba68c42bf3435ba6072db"
-  integrity sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==
+  version "2.13.1"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.13.1.tgz#ad0d7532c6fea9da1ebdc82742d74525c6273384"
+  integrity sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==
   dependencies:
-    has "^1.0.3"
+    hasown "^2.0.0"
 
 is-docker@^3.0.0:
   version "3.0.0"
@@ -1879,7 +1881,7 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
-jiti@^1.18.2:
+jiti@^1.19.1:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-1.20.0.tgz#2d823b5852ee8963585c8dd8b7992ffc1ae83b42"
   integrity sha512-3TV69ZbrvV6U5DfQimop50jE9Dl6J8O1ja1dvBbMba/sZ3YBEQqJ2VZRoQPVnhlzjNtU1vaXRZVrVjU4qtm8yA==
@@ -2167,26 +2169,6 @@ mdast-util-to-string@^3.0.0, mdast-util-to-string@^3.1.0:
   integrity sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==
   dependencies:
     "@types/mdast" "^3.0.0"
-
-mdast-util-to-string@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz#7a5121475556a04e7eddeb67b264aae79d312814"
-  integrity sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==
-  dependencies:
-    "@types/mdast" "^4.0.0"
-
-mdast-util-toc@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/mdast-util-toc/-/mdast-util-toc-7.0.0.tgz#d09715600eb32a053345803010a9b394bf5af179"
-  integrity sha512-C28UcSqjmnWuvgT8d97qpaItHKvySqVPAECUzqQ51xuMyNFFJwcFoKW77KoMjtXrclTidLQFDzLUmTmrshRweA==
-  dependencies:
-    "@types/mdast" "^4.0.0"
-    "@types/ungap__structured-clone" "^0.3.0"
-    "@ungap/structured-clone" "^1.0.0"
-    github-slugger "^2.0.0"
-    mdast-util-to-string "^4.0.0"
-    unist-util-is "^6.0.0"
-    unist-util-visit "^5.0.0"
 
 merge-stream@^2.0.0:
   version "2.0.0"
@@ -3053,14 +3035,6 @@ remark-smartypants@^2.0.0:
     retext-smartypants "^5.1.0"
     unist-util-visit "^4.1.0"
 
-remark-toc@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/remark-toc/-/remark-toc-9.0.0.tgz#7197950fe218a725e3f122a48495cb0dbd4026d0"
-  integrity sha512-KJ9txbo33GjDAV1baHFze7ij4G8c7SGYoY8Kzsm2gzFpbhL/bSoVpMMzGa3vrNDSWASNd/3ppAqL7cP2zD6JIA==
-  dependencies:
-    "@types/mdast" "^4.0.0"
-    mdast-util-toc "^7.0.0"
-
 resolve@^1.1.7, resolve@^1.22.2, resolve@^1.22.4:
   version "1.22.8"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.8.tgz#b6c87a9f2aa06dfab52e3d70ac8cde321fa5a48d"
@@ -3408,19 +3382,19 @@ supports-preserve-symlinks-flag@^1.0.0:
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
 tailwindcss@^3.0.24:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-3.3.3.tgz#90da807393a2859189e48e9e7000e6880a736daf"
-  integrity sha512-A0KgSkef7eE4Mf+nKJ83i75TMyq8HqY3qmFIJSWy8bNt0v1lG7jUcpGpoTFxAwYcWOphcTBLPPJg+bDfhDf52w==
+  version "3.3.5"
+  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-3.3.5.tgz#22a59e2fbe0ecb6660809d9cc5f3976b077be3b8"
+  integrity sha512-5SEZU4J7pxZgSkv7FP1zY8i2TIAOooNZ1e/OGtxIEv6GltpoiXUqWvLy89+a10qYTB1N5Ifkuw9lqQkN9sscvA==
   dependencies:
     "@alloc/quick-lru" "^5.2.0"
     arg "^5.0.2"
     chokidar "^3.5.3"
     didyoumean "^1.2.2"
     dlv "^1.1.3"
-    fast-glob "^3.2.12"
+    fast-glob "^3.3.0"
     glob-parent "^6.0.2"
     is-glob "^4.0.3"
-    jiti "^1.18.2"
+    jiti "^1.19.1"
     lilconfig "^2.1.0"
     micromatch "^4.0.5"
     normalize-path "^3.0.0"


### PR DESCRIPTION
Adds a better table-of-contents on markdown page -- just the rules right now -- that's always accessible.

This is half of #2.

## Screenshots
The trick is that the button changes slightly so it looks better when it's hovering over the content on the smallest screen sizes (portrait-orientation phone) vs. when it's over the lavender void space to the right of the content box.

### Large Screen (desktop)
![image](https://github.com/nie7321/homestuck-atcg/assets/27235866/412565f3-caef-4182-861f-5d6f320ff264)
![image](https://github.com/nie7321/homestuck-atcg/assets/27235866/e6eb41cd-1676-4855-9e00-8ed9774f6981)

### Medium Screen (tablet)
![image](https://github.com/nie7321/homestuck-atcg/assets/27235866/02a14b18-5cf2-46e5-8ede-cbb367763625)
![image](https://github.com/nie7321/homestuck-atcg/assets/27235866/2f11452f-11a7-4ef8-8f2e-695e2cc92076)

### Smol Screen (phone)
![image](https://github.com/nie7321/homestuck-atcg/assets/27235866/022c0e37-a65c-4dbf-89c1-415f509a3f97)
![image](https://github.com/nie7321/homestuck-atcg/assets/27235866/ae6ad4b0-92fc-433f-a3cc-9e4f810f2bc9)

## TODO
- [x] Remove remarkToc?
